### PR TITLE
Including 'v1' optionrow

### DIFF
--- a/src/App-v1.jsx
+++ b/src/App-v1.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import LeftPanel from "./components/LeftPanel";
+import RightPanel from "./components/RightPanel";
+import { PlanProvider } from "./components/PlanContext";
+
+export default function App() {
+  return (
+    <PlanProvider>
+      <div className="max-w-[1200px] mx-auto px-4 py-6">
+        <div className="flex flex-col md:flex-row gap-6">
+          <div className="w-full md:w-2/3">
+            <LeftPanel />
+          </div>
+          <div className="w-full md:w-1/3 bg-gray-100 p-4 rounded-md shadow-sm">
+            <RightPanel />
+          </div>
+        </div>
+      </div>
+    </PlanProvider>
+  );
+}

--- a/src/App-v3-old.jsx
+++ b/src/App-v3-old.jsx
@@ -1,0 +1,25 @@
+import { PlanProvider } from './components/PlanContext';
+import OptionRow from './components/OptionRow';
+
+export default function App() {
+  return (
+    <PlanProvider>
+      <div className="p-6 space-y-6">
+        <h1 className="text-2xl font-bold text-indigo-600">
+          Testing OptionRow 3.0
+        </h1>
+        <OptionRow
+          groupId="test-group"
+          option={{
+            id: 'opt-1',
+            name: 'Sample Option',
+            price: 9.99,
+            qty: 3,
+            min: 1,
+          }}
+        />
+      </div>
+    </PlanProvider>
+  );
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
+import React from "react";
 import { PlanProvider } from './components/PlanContext';
 import OptionRow from './components/OptionRow';
+import LeftPanel from "./components/LeftPanel";
 
 export default function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,21 @@
 import React from "react";
-import { PlanProvider } from './components/PlanContext';
-import OptionRow from './components/OptionRow';
 import LeftPanel from "./components/LeftPanel";
+import RightPanel from "./components/RightPanel";
+import { PlanProvider } from "./components/PlanContext";
 
 export default function App() {
   return (
     <PlanProvider>
-      <div className="p-6 space-y-6">
-        <h1 className="text-2xl font-bold text-indigo-600">
-          Testing OptionRow 3.0
-        </h1>
-        <OptionRow
-          groupId="test-group"
-          option={{
-            id: 'opt-1',
-            name: 'Sample Option',
-            price: 9.99,
-            qty: 3,
-            min: 1,
-          }}
-        />
+      <div className="max-w-[1200px] mx-auto px-4 py-6">
+        <div className="flex flex-col md:flex-row gap-6">
+          <div className="w-full md:w-2/3">
+            <LeftPanel />
+          </div>
+          <div className="w-full md:w-1/3 bg-gray-100 p-4 rounded-md shadow-sm">
+            <RightPanel />
+          </div>
+        </div>
       </div>
     </PlanProvider>
   );
 }
-

--- a/src/components/AddonTableRow.jsx
+++ b/src/components/AddonTableRow.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect } from "react";
+import { usePlan } from "./PlanContext";
+import { FaTrash } from "react-icons/fa";
+
+export default function AddonTableRow({ option, index, groupId, isLast }) {
+  const { selected, addOrUpdate, remove } = usePlan();
+  const current = selected[groupId]?.[option.id];
+  const qty = current?.qty || 0;
+
+  useEffect(() => {
+    if (option.min && qty < option.min) {
+      addOrUpdate(groupId, option.id, { ...option, qty: option.min });
+    }
+  }, []);
+
+  const updateQty = (newQty) => {
+    if (newQty > 0) {
+      addOrUpdate(groupId, option.id, { ...option, qty: newQty });
+    } else {
+      remove(groupId, option.id);
+    }
+  };
+
+  return (
+    <div className={`grid grid-cols-[60px_120px_120px_1fr_80px_80px] gap-4 items-center py-3 ${!isLast ? 'border-b' : ''}`}>
+      <div>{index + 1}</div>
+      <div>{option.term}</div>
+      <div>{option.billing}</div>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center rounded-md border border-black overflow-hidden text-sm h-[32px]">
+          <button
+            onClick={() => updateQty(Math.max(0, qty - 1))}
+            className="px-2 text-sm text-gray-500 h-full"
+          >
+            −
+          </button>
+          <div className="h-full w-[52px] text-sm border-x border-black font-medium flex items-center justify-center text-center">
+            {qty}
+          </div>
+          <button
+            onClick={() => updateQty(qty + 1)}
+            className="px-2 text-sm text-black h-full"
+          >
+            +
+          </button>
+        </div>
+        {option.min ? (
+          <div className="text-xs text-gray-500 whitespace-nowrap">Min {option.min}</div>
+        ) : null}
+      </div>
+      <div className="text-right">£{option.price}</div>
+      <div>
+        <div className="w-[88px] h-[32px]">
+          {current ? (
+            <button
+              className="w-full h-full flex items-center justify-center text-sm px-2 rounded-md border border-gray-300 bg-white"
+              onClick={() => updateQty(0)}
+              title="Remove"
+            >
+              <FaTrash className="text-red-500 text-[14px]" />
+            </button>
+          ) : (
+            <button
+              className="w-full h-full text-sm text-white px-2 rounded-md"
+              style={{ backgroundColor: '#A34796' }}
+              onClick={() => updateQty(option.min || 1)}
+            >
+              Add
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ItemGroup.jsx
+++ b/src/components/ItemGroup.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { FaChevronDown, FaChevronRight } from "react-icons/fa";
+import AddonTableRow from "./AddonTableRow";
+
+export default function ItemGroup({ group, selectedCount }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="border-b pb-4 mb-6">
+      <div
+        className="flex justify-between items-center cursor-pointer"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center gap-2">
+          {isOpen ? (
+            <FaChevronDown className="text-sm" />
+          ) : (
+            <FaChevronRight className="text-sm" />
+          )}
+          <div className="font-semibold">{group.name}</div>
+        </div>
+        <div className="text-sm text-gray-500">
+          {group.options.length} options available
+        </div>
+        {selectedCount > 0 && (
+          <div className="text-sm font-semibold text-black ml-4">
+            {selectedCount} selected
+          </div>
+        )}
+      </div>
+
+      {isOpen && group.options.length > 0 && (
+        <>
+          <div className="grid grid-cols-[60px_120px_120px_1fr_80px_80px] gap-4 text-sm font-semibold text-gray-700 border-b py-2 mt-3">
+            <div>Option</div>
+            <div>Term</div>
+            <div>Billing</div>
+            <div>Licence</div>
+            <div className="text-right">Price</div>
+            <div></div>
+          </div>
+          {group.options.map((opt, idx) => (
+            <AddonTableRow
+              key={opt.id}
+              index={idx}
+              groupId={group.id}
+              option={opt}
+              isLast={idx === group.options.length - 1}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/LeftPanel.jsx
+++ b/src/components/LeftPanel.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import { usePlan } from "./PlanContext";
+import AddonTableRow from "./AddonTableRow";
+import { FaChevronDown, FaChevronRight } from "react-icons/fa";
+
+const data = [
+  {
+    name: "MS365 Business Basic",
+    id: "ms365",
+    options: [
+      { id: "1", term: "Monthly", billing: "Monthly", price: 7, min: 10 },
+      { id: "2", term: "Monthly", billing: "Annual", price: 7, min: 0 },
+      { id: "3", term: "Annual", billing: "Annual", price: 7, min: 0 },
+    ],
+  },
+  {
+    name: "Something else",
+    id: "other-1",
+    options: [],
+  },
+  {
+    name: "Something else",
+    id: "other-2",
+    options: [],
+  },
+];
+
+export default function LeftPanel() {
+  const { selected } = usePlan();
+  const [expandedGroups, setExpandedGroups] = useState(() =>
+    Object.fromEntries(data.map((group) => [group.id, true]))
+  );
+
+  const toggleGroup = (groupId) => {
+    setExpandedGroups((prev) => ({
+      ...prev,
+      [groupId]: !prev[groupId],
+    }));
+  };
+
+  return (
+    <div>
+      {data.map((group) => {
+        const selectedCount = selected[group.id]
+          ? Object.keys(selected[group.id]).length
+          : 0;
+        const isExpanded = expandedGroups[group.id];
+
+        return (
+          <div key={group.id} className="border-b pb-4 mb-6">
+            <div
+              className="flex justify-between items-center cursor-pointer"
+              onClick={() => toggleGroup(group.id)}
+            >
+              <div className="flex items-center gap-2">
+                {isExpanded ? (
+                  <FaChevronDown className="text-sm" />
+                ) : (
+                  <FaChevronRight className="text-sm" />
+                )}
+                <div className="font-semibold">{group.name}</div>
+              </div>
+              <div className="text-sm text-gray-500">
+                {group.options.length} options available
+              </div>
+              {selectedCount > 0 && (
+                <div className="text-sm font-semibold text-black ml-4">
+                  {selectedCount} selected
+                </div>
+              )}
+            </div>
+
+            {isExpanded && group.options.length > 0 && (
+              <>
+                <div className="grid grid-cols-[60px_120px_120px_1fr_80px_80px] gap-4 text-sm font-semibold text-gray-700 border-b py-2 mt-3">
+                  <div>Option</div>
+                  <div>Term</div>
+                  <div>Billing</div>
+                  <div>Licence</div>
+                  <div className="text-right">Price</div>
+                  <div></div>
+                </div>
+                {group.options.map((opt, idx) => (
+                  <AddonTableRow
+                    key={opt.id}
+                    index={idx}
+                    groupId={group.id}
+                    option={opt}
+                    isLast={idx === group.options.length - 1}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/OptionRow.jsx
+++ b/src/components/OptionRow.jsx
@@ -5,6 +5,7 @@ import { FaTrash } from "react-icons/fa";
 export default function OptionRow({ groupId, option }) {
   const { selected, addOrUpdate, remove } = usePlan();
   const current = selected[groupId]?.[option.id];
+
   const [qty, setQty] = useState(current?.qty || 0);
 
   useEffect(() => {
@@ -25,38 +26,30 @@ export default function OptionRow({ groupId, option }) {
   };
 
   return (
-    <div className="flex items-center justify-between border p-4 rounded shadow-sm bg-white max-w-xl mb-4">
-      <div>
-        <h3 className="font-semibold text-lg text-gray-800">{option.name}</h3>
-        <p className="text-sm text-gray-600">ID: {option.id}</p>
-        <p className="text-sm text-gray-600">Price: £{option.price.toFixed(2)}</p>
-        <p className="text-sm text-gray-600">Min: {option.min}</p>
+    <div className="flex items-center gap-2 my-2">
+      <div className="flex gap-2 items-center border px-2 py-1 rounded">
+        <button onClick={() => handleUpdate(Math.max(0, qty - 1))}>−</button>
+        <span>{qty}</span>
+        <button onClick={() => handleUpdate(qty + 1)}>+</button>
       </div>
-
-      <div className="flex items-center space-x-2">
+      <span>£{option.price}</span>
+      {current ? (
         <button
-          onClick={() => handleUpdate(Math.max(0, qty - 1))}
-          className="px-3 py-1 text-sm font-medium bg-gray-200 rounded hover:bg-gray-500"
+          className="w-[64px] ml-auto flex items-center justify-center text-sm px-4 py-2 rounded-md border border-gray-300 bg-white"
+          onClick={() => handleUpdate(0)}
+          title="Remove"
         >
-          –
+          <FaTrash className="text-red-500 text-sm" />
         </button>
-        <span className="px-3 text-sm font-semibold">{qty}</span>
+      ) : (
         <button
-          onClick={() => handleUpdate(qty + 1)}
-          className="px-3 py-1 text-sm font-medium bg-gray-200 rounded hover:bg-gray-300"
+          className="w-[64px] ml-auto text-sm text-white px-4 py-2 rounded-md"
+          style={{ backgroundColor: '#A34796' }}
+          onClick={() => handleUpdate(option.min || 1)}
         >
-          +
+          Add
         </button>
-        {qty > 0 && (
-          <button
-            onClick={() => handleUpdate(0)}
-            className="text-red-500 ml-2"
-            title="Remove"
-          >
-            <FaTrash />
-          </button>
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/PlanContext-v3-old.jsx
+++ b/src/components/PlanContext-v3-old.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from "react";
+
+const PlanContext = createContext();
+
+export const PlanProvider = ({ children }) => {
+  const [selected, setSelected] = useState({});
+
+  const addOrUpdate = (group, optionId, option) => {
+    setSelected((prev) => {
+      const next = { ...prev };
+      if (!next[group]) next[group] = {};
+      next[group][optionId] = option;
+      return next;
+    });
+  };
+
+  const remove = (group, optionId) => {
+    setSelected((prev) => {
+      const next = { ...prev };
+      if (next[group]) {
+        delete next[group][optionId];
+        if (Object.keys(next[group]).length === 0) delete next[group];
+      }
+      return next;
+    });
+  };
+
+  return (
+    <PlanContext.Provider value={{ selected, addOrUpdate, remove }}>
+      {children}
+    </PlanContext.Provider>
+  );
+};
+
+export const usePlan = () => useContext(PlanContext);

--- a/src/components/RightPanel.jsx
+++ b/src/components/RightPanel.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { usePlan } from "./PlanContext";
+import { FaTrash } from "react-icons/fa";
+
+export default function RightPanel() {
+  const { selected, remove, addOrUpdate } = usePlan();
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">Title</h2>
+      {Object.entries(selected).map(([groupId, options]) =>
+        Object.entries(options).map(([optionId, opt]) => (
+          <div key={optionId} className="mb-6 border-b pb-4">
+            <h3 className="font-semibold text-sm mb-1">{opt.name || groupId}</h3>
+            <div className="text-sm text-gray-700">{`Option ${optionId} £${opt.price}`}</div>
+            <div className="text-sm text-gray-500 mb-1">{`${opt.term} / ${opt.billing}`}</div>
+            <div className="flex items-center gap-2">
+              <button onClick={() => addOrUpdate(groupId, optionId, { ...opt, qty: Math.max(0, opt.qty - 1) })}>−</button>
+              <span>{opt.qty}</span>
+              <button onClick={() => addOrUpdate(groupId, optionId, { ...opt, qty: opt.qty + 1 })}>+</button>
+              <button
+                className="ml-auto flex items-center justify-center text-sm px-4 py-2.5 rounded-md"
+                onClick={() => remove(groupId, optionId)}
+                title="Remove"
+              >
+                <FaTrash className="text-red-500 text-sm" />
+              </button>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Included core files from a preview v1 working state

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/ellroberts/bi-directional-v3/tree/including-'v1'-optionrow"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/ellroberts/bi-directional-v3/tree/including-'v1'-optionrow)._